### PR TITLE
Front: 랭크 디자인 수정

### DIFF
--- a/frontend/src/components/header/index.tsx
+++ b/frontend/src/components/header/index.tsx
@@ -13,12 +13,12 @@ export default function Header() {
             <div className={cx('ext')}>
                 <ul className={cx('ul')}>
                     <li className={cx('list')}>
-                        <a className={cx('a', 'ex')} href="https://www.acmicpc.net/">
+                        <a className={cx('a', 'ex')} href="https://www.acmicpc.net/school/ranklist/194">
                             백준
                         </a>
                     </li>
                     <li className={cx('list')}>
-                        <a className={cx('a', 'ex')} href="https://solved.ac/">
+                        <a className={cx('a', 'ex')} href="https://solved.ac/ranking/o/194">
                             solved
                         </a>
                     </li>

--- a/frontend/src/components/weeklybest/index.tsx
+++ b/frontend/src/components/weeklybest/index.tsx
@@ -43,36 +43,58 @@ export default function WeeklyBest() {
             <div className={cx('title')}>명예의 전당</div>
             <div className={cx('desc')}>(기록은 매주 월요일 초기화됩니다.)</div>
             <div className={ cx('buttonSet')}>
-                <button
-                    className={cx(!feat && 'selected', 'button')}
-                    onClick={() => {
-                        setFeat(false)
-                    }}
-                >
-                    푼 문제
-                </button>
-                <button
-                    className={cx(feat && 'selected', 'button')}
-                    onClick={() => {
-                        setFeat(true)
-                    }}
-                >
-                    랭킹 기여
-                </button>
+                {/*<button*/}
+                {/*    className={cx(!feat && 'selected', 'button')}*/}
+                {/*    onClick={() => {*/}
+                {/*        setFeat(false)*/}
+                {/*    }}*/}
+                {/*>*/}
+                {/*    푼 문제*/}
+                {/*</button>*/}
+                {/*<button*/}
+                {/*    className={cx(feat && 'selected', 'button')}*/}
+                {/*    onClick={() => {*/}
+                {/*        setFeat(true)*/}
+                {/*    }}*/}
+                {/*>*/}
+                {/*    랭킹 기여*/}
+                {/*</button>*/}
             </div>
-            {(feat
-                ? contribData : data).map((value, i) => {
-                      return (
-                          <a href={`https://www.acmicpc.net/user/${value['name']}`} className={cx('a')} key={i}>
-                              <div className={cx(i === 0 ? 'first' : i <= 3 ? 'second' : 'third', 'item')}>
-                                  <AiFillTrophy className={cx('icon')} />
-                                  <div className={cx('rank')}>{i + 1}</div>
-                                  <div className={cx('name')}>{value['name']}</div>
-                                  <div className={cx('cnt')}>{value['cnt']} solved</div>
-                              </div>
-                          </a>
+            <div className={cx('rank-wrapper')}>
+
+                <div className={cx('solved-rank')}>
+                    <div className={cx('rank-title')}>푼 문제</div>
+                {data.map((value, i) => {
+                          return (
+                              <a href={`https://www.acmicpc.net/user/${value['name']}`} className={cx('a')} key={i}>
+                                  <div className={cx(i === 0 ? 'first' : i <= 3 ? 'second' : 'third', 'item')}>
+                                      {/*<AiFillTrophy className={cx('icon')} />*/}
+                                      <div className={cx('rank')}>#{i + 1}</div>
+                                      <div className={cx('name')}>{value['name']}</div>
+                                      <div className={cx('cnt')}>{value['cnt']}</div>
+                                  </div>
+                              </a>
                       )
-                  })}
+                  })
+                }
+                </div>
+                <div className={cx('distribution-rank')}>
+                    <div className={cx('rank-title')}>학교 랭킹 기여</div>
+                    {contribData.map((value, i) => {
+                        return (
+                            <a href={`https://www.acmicpc.net/user/${value['name']}`} className={cx('a')} key={i}>
+                                <div className={cx(i === 0 ? 'first' : i <= 3 ? 'second' : 'third', 'item')}>
+                                    {/*<AiFillTrophy className={cx('icon')} />*/}
+                                    <div className={cx('rank')}>#{i + 1}</div>
+                                    <div className={cx('name')}>{value['name']}</div>
+                                    <div className={cx('cnt')}>{value['cnt']}</div>
+                                </div>
+                            </a>
+                        )
+                    })
+                    }
+                </div>
+            </div>
         </div>
     )
 }

--- a/frontend/src/components/weeklybest/index.tsx
+++ b/frontend/src/components/weeklybest/index.tsx
@@ -60,20 +60,8 @@ export default function WeeklyBest() {
                     랭킹 기여
                 </button>
             </div>
-            {feat
-                ? contribData.map((value, i) => {
-                      return (
-                          <a href={`https://www.acmicpc.net/user/${value['name']}`} className={cx('a')} key={i}>
-                              <div className={cx(i === 0 ? 'first' : i <= 3 ? 'second' : 'third', 'item')}>
-                                  <AiFillTrophy className={cx('icon')} />
-                                  <div className={cx('rank')}>{i + 1}</div>
-                                  <div className={cx('name')}>{value['name']}</div>
-                                  <div className={cx('cnt')}>{value['cnt']} solved</div>
-                              </div>
-                          </a>
-                      )
-                  })
-                : data.map((value, i) => {
+            {(feat
+                ? contribData : data).map((value, i) => {
                       return (
                           <a href={`https://www.acmicpc.net/user/${value['name']}`} className={cx('a')} key={i}>
                               <div className={cx(i === 0 ? 'first' : i <= 3 ? 'second' : 'third', 'item')}>

--- a/frontend/src/components/weeklybest/weeklybest.module.scss
+++ b/frontend/src/components/weeklybest/weeklybest.module.scss
@@ -15,11 +15,14 @@
 }
 
 .title {
+    margin-top: 50px;
+    text-align: center;
     font-size: 2.5vh;
     font-weight: bold;
 }
 
 .desc {
+    text-align: center;
     padding: 5px;
 }
 

--- a/frontend/src/components/weeklybest/weeklybest.module.scss
+++ b/frontend/src/components/weeklybest/weeklybest.module.scss
@@ -31,18 +31,39 @@
     }
 }
 
-.item {
-    border: solid 1px black;
-    margin: 10px auto;
-    height: 15vh;
+.rank-wrapper{
+    margin-top: 30px;
+    width:100%;
     display: flex;
-    align-items: center;
+    flex-direction: row;
+    column-gap: 10%;
     justify-content: center;
+    & .solved-rank, & .distribution-rank {
+        width:40%;
+        text-align: center;
+    }
+    & .rank-title {
+        font-weight: 900;
+        font-size: 2vh;
+        border-bottom: 1px solid gray;
+    }
+}
+
+.item {
+    border-bottom: dashed 1px gray;
+    height: 5vh;
+    display: flex;
+    width: 100%;
+    justify-content: center;
+    align-items: center;
     @include desktop {
-        font-size: 4vh;
+        font-size: 2.5vh;
     }
     @include tablet {
-        font-size: 3vh;
+        font-size: 2vh;
+    }
+    @include mobile {
+        font-size: 3.5vw;
     }
 
     & .icon {
@@ -56,28 +77,29 @@
             font-size: 7vw;
         }
     }
-    &.first .icon {
+    &.first .icon, &.first .rank{
         color: $gold;
     }
-    &.second .icon {
+    &.second .icon, &.second .rank{
         color: $silver;
     }
-    &.third .icon {
+    &.third .icon, &.third .rank{
         color: $bronze;
     }
 
     & .rank {
-        width: 5%;
+        width: 20%;
         text-align: center;
-        margin-left: 30px;
+        font-weight:800;
     }
     & .name {
-        width: 30%;
+        width: 60%;
         text-align: center;
     }
     & .cnt {
-        width: 30%;
+        width: 20%;
         text-align: center;
+        font-weight:800;
     }
 }
 


### PR DESCRIPTION
안녕하세요! 랭크 디자인이 너무 넓은 것 같아 두 랭크가 다 보이도록 디자인을 수정해 봤습니다.

- header의 백준, solved.ac 링크가 학교 페이지로 연결되도록 수정했습니다. 이건 편하신 대로 바꾸면 될 것 같아요

- 랭크 표의 버튼을 삭제(주석 처리)하고, 두 열로 모두 보이도록 수정했습니다.
- 트로피 아이콘을 삭제(주석 처리)하고, #{순위}로 수정했습니다. 또, 순위 번호에는 트로피 색을 매겼습니다.
- 랭크 표의 폰트 크기를 낮췄습니다. 아직도 큰 감이 있는 것 같은데,, 제가 vh vw를 잘 쓸 줄 몰라서 어려워요 😢 
- 폰트 크기 변경에 따른 모바일-태블릿도 크기를 수정했습니다.
- 두 랭크 표를 감싸는 div .rank-wrapper를 flex로 만들어서 가운데 정렬해 두었습니다. 내부 div(flex)의 width가 꽉 차도록 수정했습니다.
- 명예의 전당 글씨를 가운데 정렬했습니다.

크롬 기준으로는 모바일-태블릿-PC 괜찮아 보이는데, 확인해보시고 더 수정할 거 있으면 입맛대로 수정하셔도 될 것 같습니다!
시험기간이라 공부 빼고 다 손에 잡히네요.. 멋진 프로젝트 감사해요 !