### PR TITLE
Front: 티어페이지 디자인

### DIFF
--- a/frontend/src/components/pages/TagPage/index.tsx
+++ b/frontend/src/components/pages/TagPage/index.tsx
@@ -25,8 +25,8 @@ export default function TagPage() {
                 var tmp = []
                 const title = [
                     <li key={-1} className={cx('list', 'title')}>
-                        <span className={cx('name')}>레벨</span>
-                        <span className={cx('value')}>해결 수 / 문제 수</span>
+                        <span className={cx('name')}>알고리즘 태그</span>
+                        <span className={cx('value')}>해결한 문제 / 전체 문제</span>
                     </li>,
                 ]
                 for (var i in res) tmp.push({ name: i, ...res[i] })

--- a/frontend/src/components/pages/TierPage/TierPage.module.scss
+++ b/frontend/src/components/pages/TierPage/TierPage.module.scss
@@ -1,49 +1,50 @@
 @import '../../_config/config.scss';
 
-.list {
-    height: 5vh;
-    font-size: 2vh;
-    display: flex;
-    align-items: center;
-}
-
-.name {
-    width: 40%;
-    text-align: center;
-    // background-color: yellow;
-}
-
-.value {
-    width: 60%;
-    text-align: center;
-    // background-color: green;
-}
-
-.list:first-child{
-    border-top-right-radius: 20px;
-    border-top-left-radius: 20px;
-    font-weight:700;
-    background-color:#aaaaaa;
-}
-
-.list:nth-child(2n){
-    background-color:#ffffff;
-}
-
 .image{
     @include desktop{
-        width:1vw; 
+        width:3vw;
     }
     @include tablet{
-        width:2vh;
+        width:7vh;
     }
     @include mobile{
-        width:2vh;
+        width:5vh;
     }
-    margin-right:10px;
 }
 
-.link{
-    text-decoration: none;
-    color:black;
+.tier-wrapper{
+    text-align: center;
+    width: 70%;
+    margin: 50px auto 0 auto;
 }
+
+.tier-row{
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-bottom: 20px;
+}
+
+.tier-level{
+    position: relative;
+    height: max-content;
+    padding: 0.8vw;
+    display: inline-block;
+    text-align: center;
+}
+
+.tier-details{
+    display: flex;
+    justify-content: center;
+    opacity: 0;
+    position: absolute;
+    white-space: nowrap;
+    width: 100%;
+    left: 0;
+}
+
+.tier-level:hover > .tier-details{
+    opacity: 1;
+    transition: 0.2s opacity ease;
+}
+

--- a/frontend/src/components/pages/TierPage/index.tsx
+++ b/frontend/src/components/pages/TierPage/index.tsx
@@ -1,7 +1,6 @@
-import React, { useEffect, useState, ReactElement } from 'react'
+import React, { useEffect, useState } from 'react'
 import Menu from '../../menu'
 import Header from '../../header'
-import ItemSet from '../../itemset'
 import styles from './TierPage.module.scss'
 import classnames from 'classnames/bind'
 import { Link } from 'react-router-dom'
@@ -10,7 +9,14 @@ import URL from '../../_config/config'
 const cx = classnames.bind(styles)
 
 export default function TierPage() {
-    const [data, setData] = useState<ReactElement[]>([])
+    const [tierTable, setTierTable] = useState<Array<Array<Tier>>>([])
+    interface Tier{
+        level: number,
+        solved_cnt: number,
+        all_cnt: number
+        name: string
+    }
+
     useEffect(() => {
         var url = `${URL}/statusByLevel`
         fetch(url, {
@@ -22,40 +28,44 @@ export default function TierPage() {
         })
             .then(res => res.json())
             .then(res => {
-                var tmp = []
-                const title = [
-                    <li key={-1} className={cx('list', 'title')}>
-                        <span className={cx('name')}>레벨</span>
-                        <span className={cx('value')}>해결한 문제 / 전체 문제</span>
-                    </li>,
-                ]
-                for (var i in res) {
-                    tmp.push({ level: parseInt(i), ...res[i] })
+                var table = []
+                for(var tier = 0; tier < 6; tier++) {
+                    var tmp: Array<Tier> = []
+                    for (var tierDetail = 1; tierDetail <= 5; tierDetail++) {
+                        tmp.push({level: tier * 5 + tierDetail, ...res[tier * 5 + tierDetail]});
+                    }
+                    table.push(tmp);
                 }
-                setData(
-                    title.concat(
-                        tmp.map((value, ix) => (
-                            <li key={ix} className={cx('list')}>
-                                <span className={cx('name')}>
-                                    <img className={cx('image')} src={`https://static.solved.ac/tier_small/${value.level}.svg`} alt={value.name} />
-                                    <Link to={`/tier/${value.level}`} className={cx('link')} style={{ color: color[tier2color(value.level, true)] }}>
-                                        {value.name}
-                                    </Link>
-                                </span>
-                                <span className={cx('value')}>
-                                    {value.solved_cnt} / {value.all_cnt}
-                                </span>
-                            </li>
-                        ))
-                    )
-                )
+                table.push([{level: 0, ...res[0]}]);
+                setTierTable(table);
             })
+
     }, [])
     return (
         <div>
             <Header />
             <Menu />
-            <ItemSet data={data} />
+            <div className={cx('tier-wrapper')}>
+                {
+                    tierTable.map((row, ix) =>(
+                        <div className={cx('tier-row')}>
+                            {
+                                row.map((tier, ixx) =>(
+                                    <div className={cx('tier-level')}>
+                                        <Link to={`/tier/${tier.level}`} className={cx('link')} style={{ color: color[tier2color(tier.level, true)] }} >
+                                            <img className={cx('image')} src={`https://static.solved.ac/tier_small/${tier.level}.svg`} alt={tier.name} />
+
+                                        </Link>
+                                        <div className={cx('tier-details')} style={{ color: color[tier2color(tier.level, true)] }}>
+                                            {tier.solved_cnt} / {tier.all_cnt}
+                                        </div>
+                                    </div>
+                                ))
+                            }
+                        </div>
+                    ))
+                }
+            </div>
         </div>
     )
 }

--- a/frontend/src/components/pages/TierPage/index.tsx
+++ b/frontend/src/components/pages/TierPage/index.tsx
@@ -26,7 +26,7 @@ export default function TierPage() {
                 const title = [
                     <li key={-1} className={cx('list', 'title')}>
                         <span className={cx('name')}>레벨</span>
-                        <span className={cx('value')}>해결 수 / 문제 수</span>
+                        <span className={cx('value')}>해결한 문제 / 전체 문제</span>
                     </li>,
                 ]
                 for (var i in res) {


### PR DESCRIPTION
안녕하세요! 

기존 테이블은 다이아-루비 구간이 뒤로 페이징 돼있어서 한 번에 접근하기 어려웠습니다.
티어페이지가 한 눈에 들어오도록 수정해 보았습니다. 보는 사람 따라 느낌이 다를 것 같아 피드백 부탁드려요.
tx랑 scss 문법을 처음 접해서, 보다 나은 구현법이 있으면 적용해주시면 될 것 같아요!

- 기존 표 형식을 삭제하고 아이콘으로만 나오도록 디자인했습니다.
- 아이콘 위를 hover할 때, {푼 문제 수} / {전체 문제 수} 가 아래에 나오도록 적용했습니다. (이게 접근성이 좀 떨어지려나 모르겠습니다. 차라리 progressbar를 작게 만들어서 그냥 보이게 하는 게 나을까요 ? )
- 태블릿-모바일 호환성을 맞췄습니다.

<img src="https://user-images.githubusercontent.com/31026350/163121706-7ef2837b-b69b-42fa-a723-854c38e0dc6b.png" width="40%">
<img src="https://user-images.githubusercontent.com/31026350/163121747-49b89e3c-e85c-4422-9c2b-61d01810b934.png" width="40%">
